### PR TITLE
WIP: Add manifests for deploying and running loggy on k8s

### DIFF
--- a/k8s/00-account.yaml
+++ b/k8s/00-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-account

--- a/k8s/00-role.yaml
+++ b/k8s/00-role.yaml
@@ -1,0 +1,33 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: traefik-role
+
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update

--- a/k8s/01-role-binding.yaml
+++ b/k8s/01-role-binding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: traefik-role-binding
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-role
+subjects:
+  - kind: ServiceAccount
+    name: traefik-account
+    namespace: loggy

--- a/k8s/02-traefik-deployment.yaml
+++ b/k8s/02-traefik-deployment.yaml
@@ -1,0 +1,29 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: traefik-deployment
+  labels:
+    app: traefik
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traefik
+  template:
+    metadata:
+      labels:
+        app: traefik
+    spec:
+      serviceAccountName: traefik-account
+      containers:
+        - name: traefik
+          image: traefik:v2.8
+          args:
+            - --api.insecure
+            - --providers.kubernetesingress
+          ports:
+            - name: web
+              containerPort: 80
+            - name: dashboard
+              containerPort: 8080

--- a/k8s/02-traefik-services.yaml
+++ b/k8s/02-traefik-services.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-dashboard-service
+
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8080
+      targetPort: dashboard
+  selector:
+    app: traefik
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-web-service
+
+spec:
+  type: LoadBalancer
+  ports:
+    - targetPort: web
+      port: 80
+  selector:
+    app: traefik

--- a/k8s/03-loggy-deployment.yaml
+++ b/k8s/03-loggy-deployment.yaml
@@ -1,0 +1,31 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: loggy
+  labels:
+    app: loggy
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loggy
+  template:
+    metadata:
+      labels:
+        app: loggy
+    spec:
+      volumes:
+        - name: loggy-db-pvc
+          persistentVolumeClaim:
+            claimName: loggy-pvc
+      containers:
+        - name: loggy
+          image: localhost:32000/loggy:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: web
+              containerPort: 80
+          volumeMounts:
+            - name: loggy-db-pvc
+              mountPath: /go/src/loggy/db

--- a/k8s/03-loggy-ingress.yaml
+++ b/k8s/03-loggy-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: loggy-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: loggy
+            port:
+              name: web

--- a/k8s/03-loggy-services.yaml
+++ b/k8s/03-loggy-services.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loggy
+
+spec:
+  ports:
+    - name: web
+      port: 80
+      targetPort: web
+
+  selector:
+    app: loggy

--- a/k8s/03-loggy-storage.yaml
+++ b/k8s/03-loggy-storage.yaml
@@ -1,0 +1,8 @@
+# This PVC is to host the loggy db
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loggy-pvc
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: { requests: { storage: 1Gi } }


### PR DESCRIPTION
Details:
This is mostly WIP. Tested this with microk8s locally and it seems to work so far.

TODO: 
Added a Traefik proxy as well, next step would be to enable GRPC for it.